### PR TITLE
chore: drop package-lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+package-lock.json


### PR DESCRIPTION
## Summary
- remove package-lock from version control and ignore it going forward

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689726658a3883289f0b2842c9eef892