### PR TITLE
Add ChessGame component and tests with AI move flow

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,12 @@
 module.exports = {
   testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.(ts|tsx)$': [
+      'ts-jest',
+      {
+        tsconfig: 'tsconfig.json',
+        diagnostics: false,
+      },
+    ],
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,9 @@
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
         "jest": "^30.0.5",
-        "jest-environment-jsdom": "^30.0.5"
+        "jest-environment-jsdom": "^30.0.5",
+        "ts-jest": "^29.4.1",
+        "typescript": "^5.9.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2013,6 +2015,19 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -2672,6 +2687,28 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -4054,6 +4091,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4103,6 +4147,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -4171,6 +4222,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -4208,6 +4269,13 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5068,6 +5136,85 @@
         "node": ">=18"
       }
     },
+    "node_modules/ts-jest": {
+      "version": "29.4.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.1.tgz",
+      "integrity": "sha512-SaeUtjfpg9Uqu8IbeDKtdaS0g8lS6FT6OzM3ezrDfErPJPHNDo/Ey+VFGP1bQIDfagYDLyRpd7O15XpG1Es2Uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.8",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.7.2",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -5097,6 +5244,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/undici-types": {
@@ -5272,6 +5447,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
     "jest": "^30.0.5",
-    "jest-environment-jsdom": "^30.0.5"
+    "jest-environment-jsdom": "^30.0.5",
+    "ts-jest": "^29.4.1",
+    "typescript": "^5.9.2"
   }
 }

--- a/src/components/ChessGame.test.tsx
+++ b/src/components/ChessGame.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import { ChessGame, ChessProvider } from './ChessGame';
+
+describe('ChessGame', () => {
+  class MockWorker {
+    public onmessage: ((ev: MessageEvent) => any) | null = null;
+    public postMessage = jest.fn(() => {
+      setTimeout(() => {
+        this.onmessage && this.onmessage({ data: 'e7e5' } as MessageEvent);
+      }, 0);
+    });
+    public terminate = jest.fn();
+  }
+
+  beforeEach(() => {
+    // @ts-ignore
+    global.Worker = jest.fn(() => new MockWorker());
+  });
+
+  test('initial render and move flow with undo and reset', async () => {
+    render(
+      <ChessProvider>
+        <ChessGame />
+      </ChessProvider>
+    );
+
+    expect(screen.getByTestId('board').textContent).toBe('Board: initial');
+    expect(screen.getByTestId('move-list').children).toHaveLength(0);
+
+    fireEvent.change(screen.getByTestId('move-input'), { target: { value: 'e2e4' } });
+    fireEvent.click(screen.getByText('Submit'));
+
+    await screen.findByText('e7e5');
+    expect(screen.getByTestId('move-list').children).toHaveLength(2);
+    expect(screen.getByTestId('board').textContent).toBe('Board: e7e5');
+
+    fireEvent.click(screen.getByText('Undo'));
+    await waitFor(() => expect(screen.queryByText('e7e5')).toBeNull());
+    expect(screen.getByTestId('move-list').children).toHaveLength(1);
+    expect(screen.getByTestId('board').textContent).toBe('Board: e2e4');
+
+    fireEvent.click(screen.getByText('Reset'));
+    expect(screen.getByTestId('move-list').children).toHaveLength(0);
+    expect(screen.getByTestId('board').textContent).toBe('Board: initial');
+  });
+});

--- a/src/components/ChessGame.tsx
+++ b/src/components/ChessGame.tsx
@@ -1,0 +1,91 @@
+import React, { useReducer, useRef, useEffect, useContext, useState } from 'react';
+
+// Simple store implementation using React context
+interface State {
+  moves: string[];
+  board: string;
+}
+
+type Action =
+  | { type: 'MOVE'; move: string }
+  | { type: 'UNDO' }
+  | { type: 'RESET' };
+
+const initialState: State = { moves: [], board: 'initial' };
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'MOVE':
+      return { moves: [...state.moves, action.move], board: action.move };
+    case 'UNDO': {
+      const moves = state.moves.slice(0, -1);
+      return { moves, board: moves[moves.length - 1] || 'initial' };
+    }
+    case 'RESET':
+      return initialState;
+    default:
+      return state;
+  }
+}
+
+const StoreCtx = React.createContext<{
+  state: State;
+  dispatch: React.Dispatch<Action>;
+} | null>(null);
+
+export const ChessProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  return <StoreCtx.Provider value={{ state, dispatch }}>{children}</StoreCtx.Provider>;
+};
+
+function useStore() {
+  const ctx = useContext(StoreCtx);
+  if (!ctx) throw new Error('Store not found');
+  return ctx;
+}
+
+export const ChessGame: React.FC = () => {
+  const { state, dispatch } = useStore();
+  const [move, setMove] = useState('');
+  const workerRef = useRef<Worker | null>(null);
+
+  if (!workerRef.current) {
+    workerRef.current = new Worker('worker.js');
+  }
+
+  useEffect(() => {
+    const worker = workerRef.current!;
+    worker.onmessage = (e: MessageEvent) => {
+      dispatch({ type: 'MOVE', move: String(e.data) });
+    };
+    return () => worker.terminate();
+  }, [dispatch]);
+
+  const submit = () => {
+    if (!move) return;
+    dispatch({ type: 'MOVE', move });
+    workerRef.current!.postMessage(move);
+    setMove('');
+  };
+
+  return (
+    <div>
+      <div data-testid="board">Board: {state.board}</div>
+      <input
+        data-testid="move-input"
+        value={move}
+        onChange={e => setMove(e.target.value)}
+      />
+      <button onClick={submit}>Submit</button>
+      <button onClick={() => dispatch({ type: 'UNDO' })}>Undo</button>
+      <button onClick={() => dispatch({ type: 'RESET' })}>Reset</button>
+      <ul data-testid="move-list">
+        {state.moves.map((m, i) => (
+          <li key={i}>{m}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ChessGame;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noImplicitAny": false
+  }
+}


### PR DESCRIPTION
## Summary
- create simple ChessGame component with context store and worker-based AI response
- add comprehensive test covering board render, move submission, undo, reset, and AI move list updates
- configure Jest with ts-jest and TypeScript settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68982009b1ac8328b2faf8f51a431dd0