### PR TITLE
Add tests for game store operations

### DIFF
--- a/src/store/useGameStore.test.ts
+++ b/src/store/useGameStore.test.ts
@@ -1,0 +1,44 @@
+const { createGameStore } = require('./useGameStore');
+
+describe('useGameStore', () => {
+  let store;
+  let mockWorker;
+
+  beforeEach(() => {
+    mockWorker = { postMessage: jest.fn() };
+    store = createGameStore(mockWorker);
+  });
+
+  test('sequence of valid moves updates board and history', () => {
+    store.makeMove(0); // X
+    store.makeMove(1); // O
+
+    expect(store.board[0]).toBe('X');
+    expect(store.board[1]).toBe('O');
+    expect(store.history).toHaveLength(3); // initial + two moves
+    expect(store.history[1][0]).toBe('X');
+    expect(store.history[2][1]).toBe('O');
+    expect(mockWorker.postMessage).toHaveBeenCalledTimes(2);
+  });
+
+  test('undoMove reverts to the previous state', () => {
+    store.makeMove(0);
+    store.makeMove(1);
+
+    store.undoMove();
+
+    expect(store.board[1]).toBeNull();
+    expect(store.board[0]).toBe('X');
+    expect(store.history).toHaveLength(2);
+    expect(store.currentPlayer).toBe('O');
+  });
+
+  test('resetGame clears the board and history', () => {
+    store.makeMove(0);
+    store.resetGame();
+
+    expect(store.board).toEqual(Array(9).fill(null));
+    expect(store.history).toEqual([Array(9).fill(null)]);
+    expect(store.currentPlayer).toBe('X');
+  });
+});

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -1,0 +1,49 @@
+const INITIAL_BOARD = Array(9).fill(null);
+
+function createGameStore(worker) {
+  const aiWorker = worker || { postMessage: () => {} };
+  let board = [...INITIAL_BOARD];
+  let history = [ [...board] ];
+  let currentPlayer = 'X';
+
+  function makeMove(index) {
+    if (board[index] !== null) return;
+    board[index] = currentPlayer;
+    history.push([...board]);
+    currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
+    if (aiWorker && typeof aiWorker.postMessage === 'function') {
+      aiWorker.postMessage({ board: [...board], player: currentPlayer });
+    }
+  }
+
+  function undoMove() {
+    if (history.length > 1) {
+      history.pop();
+      board = [...history[history.length - 1]];
+      currentPlayer = history.length % 2 === 1 ? 'X' : 'O';
+    }
+  }
+
+  function resetGame() {
+    board = [...INITIAL_BOARD];
+    history = [ [...board] ];
+    currentPlayer = 'X';
+  }
+
+  return {
+    get board() {
+      return board;
+    },
+    get history() {
+      return history;
+    },
+    get currentPlayer() {
+      return currentPlayer;
+    },
+    makeMove,
+    undoMove,
+    resetGame,
+  };
+}
+
+module.exports = { createGameStore, useGameStore: createGameStore() };


### PR DESCRIPTION
## Summary
- add a basic game state store and expose factory
- test game store updates, undo and reset with a mocked worker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68982008479083288f9667e76db2a778