### PR TITLE
Add chessboard UI with worker-based AI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "chess.js": "^1.4.0",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-chessboard": "^5.2.2",
+        "react-dom": "^19.1.1",
+        "zustand": "^5.0.7"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.4",
@@ -680,6 +683,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2097,6 +2153,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/chess.js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/chess.js/-/chess.js-1.4.0.tgz",
+      "integrity": "sha512-BBJgrrtKQOzFLonR0l+k64A98NLemPwNsCskwb+29bRwobUa4iTm51E1kwGPbWXAcfdDa18nad6vpPPKPWarqw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/ci-info": {
       "version": "4.3.0",
@@ -4538,6 +4600,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-chessboard": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/react-chessboard/-/react-chessboard-5.2.2.tgz",
+      "integrity": "sha512-mI4zKmNpX1+yX9oS3H4hgqXb5FnkjQvtQp33Cpg8wap6BshgSv9X2JH6ruG9YJmdRrhGAw0gCCwmYy7GAQFZxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.11.0",
+        "pnpm": ">=9.4.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
@@ -5072,9 +5152,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -5510,6 +5588,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.7.tgz",
+      "integrity": "sha512-Ot6uqHDW/O2VdYsKLLU8GQu8sCOM1LcoE8RwvLv9uuRT9s6SOHCKs0ZEOhxg+I1Ld+A1Q5lwx+UlKXXUoCZITg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,11 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "chess.js": "^1.4.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-chessboard": "^5.2.2",
+    "react-dom": "^19.1.1",
+    "zustand": "^5.0.7"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.4",

--- a/src/components/ChessGame.tsx
+++ b/src/components/ChessGame.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Chessboard } from 'react-chessboard';
+import { useGameStore } from '../useGameStore';
+
+export function ChessGame() {
+  const { fen, moves, playerMove, aiMove, undo, reset } = useGameStore();
+  const workerRef = React.useRef<Worker | null>(null);
+
+  React.useEffect(() => {
+    workerRef.current = new Worker(new URL('../worker.js', import.meta.url));
+    const worker = workerRef.current;
+    worker.onmessage = (e: MessageEvent) => {
+      if (e.data) {
+        aiMove(e.data);
+      }
+    };
+    return () => {
+      worker.terminate();
+    };
+  }, [aiMove]);
+
+  const onDrop = (source: string, target: string) => {
+    const moved = playerMove(source, target);
+    if (moved && workerRef.current) {
+      workerRef.current.postMessage({ fen: useGameStore.getState().fen });
+    }
+    return moved;
+  };
+
+  return (
+    <div>
+      <Chessboard position={fen} onPieceDrop={onDrop} />
+      <div>
+        <h3>Moves</h3>
+        <ol>
+          {moves.map((m, i) => (
+            <li key={i}>{m.san}</li>
+          ))}
+        </ol>
+      </div>
+      <button onClick={undo}>Undo</button>
+      <button onClick={reset}>Reset</button>
+    </div>
+  );
+}
+
+export default ChessGame;
+

--- a/src/useGameStore.ts
+++ b/src/useGameStore.ts
@@ -1,0 +1,50 @@
+import { Chess } from 'chess.js';
+import { create } from 'zustand';
+
+type Move = {
+  san: string;
+};
+
+interface GameState {
+  game: Chess;
+  moves: Move[];
+  fen: string;
+  playerMove: (from: string, to: string) => boolean;
+  aiMove: (move: { from: string; to: string; promotion?: string }) => void;
+  undo: () => void;
+  reset: () => void;
+}
+
+export const useGameStore = create<GameState>((set, get) => ({
+  game: new Chess(),
+  moves: [],
+  fen: new Chess().fen(),
+  playerMove: (from, to) => {
+    const game = get().game;
+    const move = game.move({ from, to, promotion: 'q' });
+    if (move) {
+      set({ moves: [...get().moves, { san: move.san }], fen: game.fen() });
+      return true;
+    }
+    return false;
+  },
+  aiMove: (move) => {
+    const game = get().game;
+    const result = game.move(move);
+    if (result) {
+      set({ moves: [...get().moves, { san: result.san }], fen: game.fen() });
+    }
+  },
+  undo: () => {
+    const game = get().game;
+    const undone = game.undo();
+    if (undone) {
+      set({ moves: get().moves.slice(0, -1), fen: game.fen() });
+    }
+  },
+  reset: () => {
+    const game = new Chess();
+    set({ game, moves: [], fen: game.fen() });
+  },
+}));
+

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,1 +1,13 @@
-self.onmessage = () => {};
+importScripts('https://cdn.jsdelivr.net/npm/chess.js@1.0.0/dist/chess.min.js');
+
+self.onmessage = (e) => {
+  const { fen } = e.data;
+  const chess = new Chess(fen);
+  const moves = chess.moves({ verbose: true });
+  if (moves.length === 0) {
+    self.postMessage(null);
+    return;
+  }
+  const move = moves[Math.floor(Math.random() * moves.length)];
+  self.postMessage({ from: move.from, to: move.to, promotion: 'q' });
+};


### PR DESCRIPTION
## Summary
- Install chess engine and board libraries
- Implement `useGameStore` for move handling, undo, and reset
- Render chessboard with move list and wire to a worker for AI responses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68982007ac608328a534eed797974552