### PR TITLE
Add worker message processing and tests

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -1,1 +1,12 @@
-self.onmessage = () => {};
+self.onmessage = (event) => {
+  const { data } = event;
+  let value = data;
+  if (data && typeof data === 'object' && 'value' in data) {
+    value = data.value;
+  }
+  if (typeof value === 'number') {
+    self.postMessage({ result: value * 2 });
+  } else {
+    self.postMessage({ error: 'Invalid input' });
+  }
+};

--- a/src/worker.test.js
+++ b/src/worker.test.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+test('worker doubles the provided value', (done) => {
+  const OriginalWorker = global.Worker;
+
+  class MockWorker {
+    constructor(url) {
+      this.onmessage = null;
+      const code = fs.readFileSync(path.resolve(__dirname, './worker.js'), 'utf8');
+      const sandbox = {
+        self: {
+          postMessage: (data) => {
+            if (this.onmessage) {
+              this.onmessage({ data });
+            }
+          },
+        },
+      };
+      vm.runInNewContext(code, sandbox);
+      this._onmessage = sandbox.self.onmessage;
+    }
+
+    postMessage(data) {
+      if (this._onmessage) {
+        this._onmessage({ data });
+      }
+    }
+
+    terminate() {}
+  }
+
+  global.Worker = MockWorker;
+
+  const worker = new Worker('./worker.js');
+  worker.onmessage = (event) => {
+    expect(event.data).toEqual({ result: 4 });
+    global.Worker = OriginalWorker;
+    done();
+  };
+  worker.postMessage({ value: 2 });
+});


### PR DESCRIPTION
## Summary
- Implement message handling in `src/worker.js` to process numeric values and return results
- Add Jest test for web worker using a mocked Worker implementation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68987fef117c8328b3d31a208be17d45