### PR TITLE
Add chess game state store using Zustand

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "chess.js": "^1.4.0",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "zustand": "^5.0.7"
       },
       "devDependencies": {
         "@playwright/test": "^1.54.2",
@@ -2905,6 +2907,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/chess.js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/chess.js/-/chess.js-1.4.0.tgz",
+      "integrity": "sha512-BBJgrrtKQOzFLonR0l+k64A98NLemPwNsCskwb+29bRwobUa4iTm51E1kwGPbWXAcfdDa18nad6vpPPKPWarqw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/ci-info": {
       "version": "4.3.0",
@@ -6663,6 +6671,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.7.tgz",
+      "integrity": "sha512-Ot6uqHDW/O2VdYsKLLU8GQu8sCOM1LcoE8RwvLv9uuRT9s6SOHCKs0ZEOhxg+I1Ld+A1Q5lwx+UlKXXUoCZITg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "chess.js": "^1.4.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "zustand": "^5.0.7"
   },
   "devDependencies": {
     "@playwright/test": "^1.54.2",

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -1,0 +1,80 @@
+import React, { createContext, useContext, useEffect, useRef } from 'react';
+import { Chess, Move } from 'chess.js';
+import { StoreApi, createStore } from 'zustand';
+import { useStore } from 'zustand';
+
+interface GameState {
+  chess: Chess;
+  moves: Move[];
+  makeMove: (from: string, to: string, isAi?: boolean) => void;
+  undoMove: () => void;
+  resetGame: () => void;
+}
+
+export type GameStore = StoreApi<GameState>;
+
+let aiWorker: Worker | null = null;
+
+function initAiWorker(store: GameStore) {
+  const worker = new Worker(new URL('../worker.js', import.meta.url));
+  worker.onmessage = (e: MessageEvent<{ from: string; to: string }>) => {
+    const { from, to } = e.data || {};
+    if (from && to) {
+      store.getState().makeMove(from, to, true);
+    }
+  };
+  return worker;
+}
+
+export const createGameStore = () =>
+  createStore<GameState>((set, get) => ({
+    chess: new Chess(),
+    moves: [],
+    makeMove: (from, to, isAi = false) => {
+      const { chess } = get();
+      const move = chess.move({ from, to });
+      if (move) {
+        set((state) => ({ moves: [...state.moves, move] }));
+        if (!isAi) {
+          aiWorker?.postMessage({ fen: chess.fen() });
+        }
+      }
+    },
+    undoMove: () => {
+      const { chess } = get();
+      chess.undo();
+      set((state) => ({ moves: state.moves.slice(0, -1) }));
+    },
+    resetGame: () => {
+      set({ chess: new Chess(), moves: [] });
+    },
+  }));
+
+const GameStoreContext = createContext<GameStore | null>(null);
+
+export function GameProvider({ children }: { children: React.ReactNode }) {
+  const storeRef = useRef<GameStore>();
+  if (!storeRef.current) {
+    storeRef.current = createGameStore();
+  }
+  useEffect(() => {
+    aiWorker = initAiWorker(storeRef.current!);
+    return () => {
+      aiWorker?.terminate();
+      aiWorker = null;
+    };
+  }, []);
+  return (
+    <GameStoreContext.Provider value={storeRef.current}>
+      {children}
+    </GameStoreContext.Provider>
+  );
+}
+
+export function useGameStore<T>(selector: (state: GameState) => T): T {
+  const store = useContext(GameStoreContext);
+  if (!store) {
+    throw new Error('useGameStore must be used within GameProvider');
+  }
+  return useStore(store, selector);
+}


### PR DESCRIPTION
## Summary
- add `chess.js` and `zustand` dependencies
- implement `useGameStore` with chess logic and web worker support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68988013c83c8328b6ce472f793ce345