### PR TITLE
feat: add chess status and promotion handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "chess.js": "^1.0.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -2905,6 +2906,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/chess.js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/chess.js/-/chess.js-1.4.0.tgz",
+      "integrity": "sha512-BBJgrrtKQOzFLonR0l+k64A98NLemPwNsCskwb+29bRwobUa4iTm51E1kwGPbWXAcfdDa18nad6vpPPKPWarqw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/ci-info": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "type": "commonjs",
   "dependencies": {
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "chess.js": "^1.0.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.54.2",

--- a/src/ChessGame.js
+++ b/src/ChessGame.js
@@ -1,0 +1,66 @@
+const React = require('react');
+const useGameStore = require('./useGameStore');
+
+function ChessGame() {
+  const { board, move, pendingPromotion, promote, status } = useGameStore();
+  const [selected, setSelected] = React.useState(null);
+
+  const handleSquareClick = (squareName) => {
+    if (selected) {
+      move(selected, squareName);
+      setSelected(null);
+    } else {
+      const [file, rank] = squareName;
+      setSelected(squareName);
+    }
+  };
+
+  const renderBoard = () => {
+    return React.createElement(
+      'div',
+      { className: 'board' },
+      board
+        .map((row, rowIndex) =>
+          row.map((square, colIndex) => {
+            const squareName = 'abcdefgh'[colIndex] + (8 - rowIndex);
+            const piece = square ? square.type + square.color : '';
+            return React.createElement(
+              'button',
+              {
+                key: squareName,
+                'data-square': squareName,
+                onClick: () => handleSquareClick(squareName),
+                className: 'square'
+              },
+              piece
+            );
+          })
+        )
+    );
+  };
+
+  const renderPromotion = () => {
+    if (!pendingPromotion) return null;
+    return React.createElement(
+      'div',
+      { className: 'promotion' },
+      ['q', 'r', 'b', 'n'].map((p) =>
+        React.createElement(
+          'button',
+          { key: p, onClick: () => promote(p) },
+          p
+        )
+      )
+    );
+  };
+
+  return React.createElement(
+    'div',
+    null,
+    renderBoard(),
+    renderPromotion(),
+    React.createElement('div', { className: 'status', 'data-testid': 'status' }, status)
+  );
+}
+
+module.exports = ChessGame;

--- a/src/useGameStore.js
+++ b/src/useGameStore.js
@@ -1,0 +1,74 @@
+const React = require('react');
+const { Chess } = require('chess.js');
+
+function useGameStore() {
+  const [game] = React.useState(() => new Chess());
+  const [status, setStatus] = React.useState('playing');
+  const [pendingPromotion, setPendingPromotion] = React.useState(null);
+
+  const updateStatus = React.useCallback(() => {
+    if (game.in_checkmate()) {
+      setStatus('checkmate');
+    } else if (game.in_stalemate()) {
+      setStatus('stalemate');
+    } else if (game.in_check()) {
+      setStatus('check');
+    } else {
+      setStatus('playing');
+    }
+  }, [game]);
+
+  const makeMove = React.useCallback(
+    (from, to, promotion) => {
+      const move = promotion ? { from, to, promotion } : { from, to };
+      const result = game.move(move);
+      if (result) {
+        updateStatus();
+      }
+      return result;
+    },
+    [game, updateStatus]
+  );
+
+  const move = React.useCallback(
+    (from, to) => {
+      const piece = game.get(from);
+      if (
+        piece &&
+        piece.type === 'p' &&
+        ((piece.color === 'w' && to[1] === '8') ||
+          (piece.color === 'b' && to[1] === '1'))
+      ) {
+        setPendingPromotion({ from, to, color: piece.color });
+        return null;
+      }
+      return makeMove(from, to);
+    },
+    [game, makeMove]
+  );
+
+  const promote = React.useCallback(
+    (piece) => {
+      if (pendingPromotion) {
+        makeMove(pendingPromotion.from, pendingPromotion.to, piece);
+        setPendingPromotion(null);
+      }
+    },
+    [pendingPromotion, makeMove]
+  );
+
+  const board = React.useMemo(() => game.board(), [game, status]);
+
+  return {
+    board,
+    move,
+    promote,
+    pendingPromotion,
+    isCheck: game.in_check(),
+    isCheckmate: game.in_checkmate(),
+    isStalemate: game.in_stalemate(),
+    status,
+  };
+}
+
+module.exports = useGameStore;


### PR DESCRIPTION
## Summary
- track check, checkmate and stalemate states in the game store via chess.js
- add pending-promotion logic and UI to choose promoted piece
- expose game status to ChessGame and render current status

## Testing
- `npm test`
- `npm run e2e` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_6898800b436083289561aa7315aba8e0