### PR TITLE
feat: migrate project to ES modules

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
-module.exports = {
+export default {
   testEnvironment: 'jsdom',
   testPathIgnorePatterns: ['/node_modules/', '/tests/'],
+  transform: {},
 };

--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "jest",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "dev": "vite",
     "e2e": "playwright test"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "dependencies": {
     "react": "^19.1.1",
     "react-dom": "^19.1.1"

--- a/src/WorkerComponent.js
+++ b/src/WorkerComponent.js
@@ -1,13 +1,13 @@
-const React = require('react');
+import React, { useRef, useEffect } from 'react';
 
-function WorkerComponent() {
-  const workerRef = React.useRef(null);
+export default function WorkerComponent() {
+  const workerRef = useRef(null);
 
   if (!workerRef.current) {
-    workerRef.current = new Worker('./worker.js');
+    workerRef.current = new Worker(new URL('./worker.js', import.meta.url));
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     const worker = workerRef.current;
     return () => {
       if (worker) {
@@ -18,5 +18,3 @@ function WorkerComponent() {
 
   return React.createElement('div', null, 'Worker Component');
 }
-
-module.exports = WorkerComponent;

--- a/src/WorkerComponent.test.js
+++ b/src/WorkerComponent.test.js
@@ -1,6 +1,7 @@
-const React = require('react');
-const { render } = require('@testing-library/react');
-const WorkerComponent = require('./WorkerComponent');
+import React from 'react';
+import { render } from '@testing-library/react';
+import WorkerComponent from './WorkerComponent.js';
+import { jest } from '@jest/globals';
 
 test('creates one worker and terminates on unmount', () => {
   const terminate = jest.fn();


### PR DESCRIPTION
## Summary
- switch project to ES modules
- update Jest to run with ESM configuration
- use `import`/`export` in component and tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68987fefd9388328a07c5cdd1cfcca1b