### PR TITLE
Persist game state and add PGN import/export

### DIFF
--- a/src/ChessGame.js
+++ b/src/ChessGame.js
@@ -1,0 +1,47 @@
+const React = require('react');
+const useGameStore = require('./useGameStore');
+
+function ChessGame() {
+  const { exportPGN, importFEN } = useGameStore();
+  const [fenInput, setFenInput] = React.useState('');
+
+  const handleDownload = React.useCallback(() => {
+    const pgn = exportPGN();
+    const blob = new Blob([pgn], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'game.pgn';
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [exportPGN]);
+
+  const handleImport = React.useCallback(() => {
+    if (fenInput) {
+      importFEN(fenInput);
+      setFenInput('');
+    }
+  }, [fenInput, importFEN]);
+
+  return React.createElement(
+    'div',
+    null,
+    React.createElement(
+      'button',
+      { onClick: handleDownload },
+      'Download PGN'
+    ),
+    React.createElement('input', {
+      value: fenInput,
+      onChange: (e) => setFenInput(e.target.value),
+      placeholder: 'Enter FEN',
+    }),
+    React.createElement(
+      'button',
+      { onClick: handleImport },
+      'Load FEN'
+    )
+  );
+}
+
+module.exports = ChessGame;

--- a/src/useGameStore.js
+++ b/src/useGameStore.js
@@ -1,0 +1,63 @@
+const React = require('react');
+
+const FEN_KEY = 'game_fen';
+const HISTORY_KEY = 'game_history';
+
+function safeJSONParse(str, fallback) {
+  try {
+    return JSON.parse(str);
+  } catch (_) {
+    return fallback;
+  }
+}
+
+function useGameStore() {
+  // initialise state from localStorage when available
+  const [fen, setFen] = React.useState(() => {
+    if (typeof localStorage !== 'undefined') {
+      return localStorage.getItem(FEN_KEY) || '';
+    }
+    return '';
+  });
+
+  const [history, setHistory] = React.useState(() => {
+    if (typeof localStorage !== 'undefined') {
+      return safeJSONParse(localStorage.getItem(HISTORY_KEY), []);
+    }
+    return [];
+  });
+
+  // persist FEN whenever it changes
+  React.useEffect(() => {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(FEN_KEY, fen);
+    }
+  }, [fen]);
+
+  // persist move history whenever it changes
+  React.useEffect(() => {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
+    }
+  }, [history]);
+
+  // add a move to history
+  const addMove = React.useCallback((move) => {
+    setHistory((h) => [...h, move]);
+  }, []);
+
+  // export the move history as a simple PGN string
+  const exportPGN = React.useCallback(() => {
+    return history.join(' ');
+  }, [history]);
+
+  // import a FEN position and reset move history
+  const importFEN = React.useCallback((newFen) => {
+    setFen(newFen);
+    setHistory([]);
+  }, []);
+
+  return { fen, setFen, history, addMove, exportPGN, importFEN };
+}
+
+module.exports = useGameStore;


### PR DESCRIPTION
## Summary
- store FEN and move history in localStorage via `useGameStore`
- expose `exportPGN` and `importFEN` helpers
- add `ChessGame` component with buttons to download PGN and load FEN text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898800b5d048328a97270bb93a4283d