### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Cache node_modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Unit tests
+        run: npm test
+      - name: E2E tests
+        run: npm run e2e
+      - name: Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: test-results

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "lint": "echo \"linting\"",
     "test": "jest",
     "dev": "vite",
     "e2e": "playwright test"


### PR DESCRIPTION
## Summary
- add GitHub Actions CI workflow to run lint, unit tests, and e2e tests
- cache Node modules and upload Playwright traces on failure
- add placeholder lint script

## Testing
- `npm ci`
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: page.click timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68988007df3c8328982f4e271876d011