### PR TITLE
Add Playwright chess E2E test

### DIFF
--- a/tests/chess.spec.ts
+++ b/tests/chess.spec.ts
@@ -4,11 +4,10 @@ test('ai responds to a legal move', async ({ page }) => {
   await page.goto('/');
 
   // Perform player's move: pawn from e2 to e4
-  await page.click('[data-square="e2"]');
-  await page.click('[data-square="e4"]');
+  await page.locator('[data-square="e2"]').click();
+  await page.locator('[data-square="e4"]').click();
 
   // Wait for AI to make a move and verify a piece appears on expected square
-  await page.waitForSelector('[data-square="e5"] .piece', { timeout: 10000 });
-  const aiPiece = await page.$('[data-square="e5"] .piece');
-  expect(aiPiece).not.toBeNull();
+  await expect(page.locator('[data-square="e5"] .piece')).toBeVisible({ timeout: 10000 });
 });
+


### PR DESCRIPTION
## Summary
- add Playwright spec that makes a legal move and waits for the AI reply

## Testing
- `npm run e2e` *(fails: locator('[data-square="e2"]') timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6898800fce148328b580a2117fc02e85