### PR TITLE
chore: migrate WorkerComponent to ES modules

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   testEnvironment: 'jsdom',
   testPathIgnorePatterns: ['/node_modules/', '/tests/'],
 };

--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "jest",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "dev": "vite",
     "e2e": "playwright test"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",

--- a/src/WorkerComponent.js
+++ b/src/WorkerComponent.js
@@ -1,4 +1,4 @@
-const React = require('react');
+import React from 'react';
 
 function WorkerComponent() {
   const workerRef = React.useRef(null);
@@ -19,4 +19,4 @@ function WorkerComponent() {
   return React.createElement('div', null, 'Worker Component');
 }
 
-module.exports = WorkerComponent;
+export default WorkerComponent;

--- a/src/WorkerComponent.test.js
+++ b/src/WorkerComponent.test.js
@@ -1,6 +1,7 @@
-const React = require('react');
-const { render } = require('@testing-library/react');
-const WorkerComponent = require('./WorkerComponent');
+import React from 'react';
+import { render } from '@testing-library/react';
+import WorkerComponent from './WorkerComponent';
+import { jest } from '@jest/globals';
 
 test('creates one worker and terminates on unmount', () => {
   const terminate = jest.fn();

--- a/src/worker.test.js
+++ b/src/worker.test.js
@@ -1,6 +1,10 @@
-const fs = require('fs');
-const path = require('path');
-const vm = require('vm');
+import fs from 'fs';
+import path from 'path';
+import vm from 'vm';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 test('worker doubles the provided value', (done) => {
   const OriginalWorker = global.Worker;


### PR DESCRIPTION
## Summary
- switch project to ES modules
- convert WorkerComponent and tests to use import/export
- adjust Jest setup for ESM

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ad44cdf248328b861172e939a4747