### PR TITLE
Add basic pawn move generation

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -1,12 +1,66 @@
-self.onmessage = (event) => {
-  const { data } = event;
-  let value = data;
-  if (data && typeof data === 'object' && 'value' in data) {
-    value = data.value;
+function generatePawnMoves(from, board, color) {
+  const moves = [];
+  const file = from.charCodeAt(0);
+  const rank = parseInt(from[1], 10);
+  const forward = color === 'w' ? 1 : -1;
+  const startRank = color === 'w' ? 2 : 7;
+  const targetRank = rank + forward;
+
+  if (targetRank >= 1 && targetRank <= 8) {
+    const leftFile = file - 1;
+    const rightFile = file + 1;
+
+    if (leftFile >= 97) {
+      const leftSq = String.fromCharCode(leftFile) + targetRank;
+      if (board[leftSq] && board[leftSq].color !== color) {
+        moves.push({ from, to: leftSq });
+      }
+    }
+
+    if (rightFile <= 104) {
+      const rightSq = String.fromCharCode(rightFile) + targetRank;
+      if (board[rightSq] && board[rightSq].color !== color) {
+        moves.push({ from, to: rightSq });
+      }
+    }
+
+    const forwardOne = String.fromCharCode(file) + targetRank;
+    const forwardTwo = String.fromCharCode(file) + (rank + forward * 2);
+
+    if (rank === startRank && !board[forwardOne] && !board[forwardTwo]) {
+      moves.push({ from, to: forwardTwo });
+    }
+
+    if (!board[forwardOne]) {
+      moves.push({ from, to: forwardOne });
+    }
   }
-  if (typeof value === 'number') {
-    self.postMessage({ result: value * 2 });
-  } else {
+
+  return moves;
+}
+
+function choosePawnMove(board, color) {
+  const squares = Object.keys(board).sort();
+  for (const sq of squares) {
+    const piece = board[sq];
+    if (piece.type === 'P' && piece.color === color) {
+      const moves = generatePawnMoves(sq, board, color);
+      if (moves.length) return moves[0];
+    }
+  }
+  return null;
+}
+
+self.onmessage = (event) => {
+  const { board, color } = event.data || {};
+  if (!board || !color) {
     self.postMessage({ error: 'Invalid input' });
+    return;
+  }
+  const move = choosePawnMove(board, color);
+  if (move) {
+    self.postMessage({ move });
+  } else {
+    self.postMessage({ error: 'No legal moves' });
   }
 };

--- a/src/worker.test.js
+++ b/src/worker.test.js
@@ -2,42 +2,65 @@ const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
 
-test('worker doubles the provided value', (done) => {
-  const OriginalWorker = global.Worker;
-
-  class MockWorker {
-    constructor(url) {
-      this.onmessage = null;
-      const code = fs.readFileSync(path.resolve(__dirname, './worker.js'), 'utf8');
-      const sandbox = {
-        self: {
-          postMessage: (data) => {
-            if (this.onmessage) {
-              this.onmessage({ data });
-            }
-          },
+class MockWorker {
+  constructor(url) {
+    const code = fs.readFileSync(path.resolve(__dirname, url), 'utf8');
+    const sandbox = {
+      self: {
+        postMessage: (data) => {
+          if (this.onmessage) {
+            this.onmessage({ data });
+          }
         },
-      };
-      vm.runInNewContext(code, sandbox);
-      this._onmessage = sandbox.self.onmessage;
-    }
-
-    postMessage(data) {
-      if (this._onmessage) {
-        this._onmessage({ data });
-      }
-    }
-
-    terminate() {}
+        onmessage: null,
+      },
+    };
+    vm.runInNewContext(code, sandbox);
+    this._onmessage = sandbox.self.onmessage;
+    this.onmessage = null;
   }
 
-  global.Worker = MockWorker;
+  postMessage(data) {
+    if (this._onmessage) {
+      this._onmessage({ data });
+    }
+  }
 
-  const worker = new Worker('./worker.js');
-  worker.onmessage = (event) => {
-    expect(event.data).toEqual({ result: 4 });
-    global.Worker = OriginalWorker;
-    done();
+  terminate() {}
+}
+
+function runWorker(input) {
+  return new Promise((resolve) => {
+    const OriginalWorker = global.Worker;
+    global.Worker = MockWorker;
+    const worker = new Worker('./worker.js');
+    worker.onmessage = (event) => {
+      resolve(event.data);
+      global.Worker = OriginalWorker;
+    };
+    worker.postMessage(input);
+  });
+}
+
+test('pawn moves two squares from starting rank', async () => {
+  const result = await runWorker({ board: { e7: { type: 'P', color: 'b' } }, color: 'b' });
+  expect(result).toEqual({ move: { from: 'e7', to: 'e5' } });
+});
+
+test('pawn moves one square when double step is blocked', async () => {
+  const board = {
+    e7: { type: 'P', color: 'b' },
+    e5: { type: 'P', color: 'w' },
   };
-  worker.postMessage({ value: 2 });
+  const result = await runWorker({ board, color: 'b' });
+  expect(result).toEqual({ move: { from: 'e7', to: 'e6' } });
+});
+
+test('pawn captures diagonally', async () => {
+  const board = {
+    e4: { type: 'P', color: 'w' },
+    d5: { type: 'P', color: 'b' },
+  };
+  const result = await runWorker({ board, color: 'w' });
+  expect(result).toEqual({ move: { from: 'e4', to: 'd5' } });
 });


### PR DESCRIPTION
## Summary
- Replace numeric placeholder worker with pawn move generator
- Return worker's selected move to main thread
- Add unit tests for pawn advance and capture moves

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ad44fe9248328a269c4b3d3c3bb96