### PR TITLE
Add build script and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,22 @@ on:
     branches: ["main"]
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Cache node_modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
   test:
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "jest",
     "dev": "vite",
+    "build": "vite build",
     "e2e": "playwright test",
     "lint": "eslint src tests",
     "format": "prettier --write ."


### PR DESCRIPTION
## Summary
- add vite build script to package.json
- run build step in CI workflow

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cf5035b1c8328ae435ae0f178ef7e