### PR TITLE
feat: support full chess starting position

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,15 @@ import { INITIAL_FEN } from './constants';
 const files = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
 const ranks = [1, 2, 3, 4, 5, 6, 7, 8];
 
+const pieceNames: Record<Piece['type'], string> = {
+  P: 'pawn',
+  K: 'king',
+  Q: 'queen',
+  R: 'rook',
+  B: 'bishop',
+  N: 'knight',
+};
+
 function pieceSymbol(piece: Piece | undefined): string | null {
   if (!piece) return null;
   const symbols: Record<string, string> = {
@@ -16,6 +25,14 @@ function pieceSymbol(piece: Piece | undefined): string | null {
     bP: '♟︎',
     wK: '♔',
     bK: '♚',
+    wQ: '♕',
+    bQ: '♛',
+    wR: '♖',
+    bR: '♜',
+    wB: '♗',
+    bB: '♝',
+    wN: '♘',
+    bN: '♞',
   };
   return symbols[piece.color + piece.type];
 }
@@ -227,10 +244,11 @@ export default function App(): JSX.Element {
               tabIndex={0}
               aria-label={`square ${sq}${
                 piece
-                  ? ' with ' +
-                    (piece.color === 'w' ? 'white' : 'black') +
-                    ' ' +
-                    (piece.type === 'P' ? 'pawn' : 'king')
+                  ?
+                      ' with ' +
+                      (piece.color === 'w' ? 'white' : 'black') +
+                      ' ' +
+                      pieceNames[piece.type]
                   : ''
               }`}
               onClick={() => handleSquareClick(sq)}

--- a/src/aiWorker.test.ts
+++ b/src/aiWorker.test.ts
@@ -80,6 +80,13 @@ test('rejects illegal move', async () => {
   });
 });
 
+test('allows knight move', async () => {
+  const worker = createWorker();
+  worker.postMessage({ type: 'INIT', fen: INITIAL_FEN });
+  const res = await post(worker, { type: 'PLAYER_MOVE', from: 'g1', to: 'f3' });
+  expect(res.type).toBe('AI_MOVE');
+});
+
 test('allows capture', async () => {
   const worker = createWorker();
   worker.postMessage({

--- a/src/boardStore.tsx
+++ b/src/boardStore.tsx
@@ -5,15 +5,29 @@ import React, {
   useMemo,
   ReactNode,
 } from 'react';
-import type { Board } from './types';
+import { Chess } from 'chess.js';
+import { INITIAL_FEN } from './constants';
+import type { Board, Piece } from './types';
+
+const files = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
 
 function initialBoard(): Board {
-  return {
-    a8: { type: 'K', color: 'b' },
-    e7: { type: 'P', color: 'b' },
-    e2: { type: 'P', color: 'w' },
-    h1: { type: 'K', color: 'w' },
-  };
+  const game = new Chess(INITIAL_FEN);
+  const b: Board = {};
+  const board = game.board();
+  for (let r = 0; r < 8; r++) {
+    for (let f = 0; f < 8; f++) {
+      const piece = board[r][f];
+      if (piece) {
+        const square = files[f] + (8 - r);
+        b[square] = {
+          type: piece.type.toUpperCase() as Piece['type'],
+          color: piece.color as Piece['color'],
+        };
+      }
+    }
+  }
+  return b;
 }
 
 function movePiece(board: Board, from: string, to: string): Board {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,2 @@
-export const INITIAL_FEN = 'k7/4p3/8/8/8/8/4P3/7K w - - 0 1';
+export const INITIAL_FEN =
+  'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 export type Color = 'w' | 'b';
 
 export interface Piece {
-  type: 'P' | 'K';
+  type: 'P' | 'K' | 'Q' | 'R' | 'B' | 'N';
   color: Color;
 }
 


### PR DESCRIPTION
## Summary
- support all piece types in `Piece.type`
- initialize board from standard chess starting FEN
- show Unicode symbols for all pieces and add knight move test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cf506cf008328b23e549b8b798385