### PR TITLE
Highlight legal moves and validate player moves

### DIFF
--- a/tests/chess.spec.ts
+++ b/tests/chess.spec.ts
@@ -5,6 +5,7 @@ test('announces player move', async ({ page }) => {
 
   // Perform player's move: pawn from e2 to e4
   await page.locator('[data-square="e2"]').click();
+  await page.locator('[data-square="e4"] [data-legal-marker]').waitFor();
   await page.locator('[data-square="e4"]').click();
 
   // Verify player's move announcement
@@ -19,11 +20,23 @@ test('board has grid roles and announces moves and orientation', async ({ page }
   await expect(grid.locator('[role="gridcell"]').first()).toBeVisible();
 
   await page.locator('[data-square="e2"]').click();
+  await page.locator('[data-square="e4"] [data-legal-marker]').waitFor();
   await page.locator('[data-square="e4"]').click();
   const announcer = page.getByTestId('announcer');
   await expect.poll(async () => await announcer.textContent()).toContain('moved');
 
   await page.getByRole('button', { name: 'Toggle board orientation' }).click();
   await expect(announcer).toHaveText(/Board orientation is now (white|black) at bottom/);
+});
+
+test('announces illegal move', async ({ page }) => {
+  await page.goto('/');
+
+  await page.locator('[data-square="e2"]').click();
+  await page.locator('[data-square="e4"] [data-legal-marker]').waitFor();
+  await page.locator('[data-square="e5"]').click();
+
+  const announcer = page.getByTestId('announcer');
+  await expect.poll(async () => await announcer.textContent()).toBe('Illegal move');
 });
 


### PR DESCRIPTION
## Summary
- fetch legal moves for a selected square from worker and highlight targets on the board
- block illegal moves with error announcement and clear highlights on deselection or move
- extend Playwright tests to cover legal move markers and illegal move handling

## Testing
- `npm test`
- `npm run e2e`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cf5093bb8832893b0b1f0fb64b97b