### PR TITLE
Fix undo logic to remove single move and add tests

### DIFF
--- a/src/store/index.test.tsx
+++ b/src/store/index.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { GameProvider, useGameStore } from './index';
+
+describe('Game store undo operations', () => {
+  const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <GameProvider>{children}</GameProvider>
+  );
+
+  test('single undo reverts the last move', () => {
+    const { result } = renderHook(() => useGameStore(), { wrapper });
+
+    act(() => {
+      result.current.playerMove('e2', 'e4');
+    });
+
+    expect(result.current.board.e4).toEqual({ type: 'P', color: 'w' });
+    expect(result.current.history).toHaveLength(2);
+    expect(result.current.moves).toEqual(['e4']);
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(result.current.board.e4).toBeUndefined();
+    expect(result.current.board.e2).toEqual({ type: 'P', color: 'w' });
+    expect(result.current.history).toHaveLength(1);
+    expect(result.current.moves).toHaveLength(0);
+  });
+
+  test('consecutive undo operations revert multiple moves', () => {
+    const { result } = renderHook(() => useGameStore(), { wrapper });
+
+    act(() => {
+      result.current.playerMove('e2', 'e4');
+      result.current.aiMove('e7', 'e5');
+    });
+
+    expect(result.current.board.e4).toEqual({ type: 'P', color: 'w' });
+    expect(result.current.board.e5).toEqual({ type: 'P', color: 'b' });
+    expect(result.current.history).toHaveLength(3);
+    expect(result.current.moves).toEqual(['e4', 'e5']);
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(result.current.board.e5).toBeUndefined();
+    expect(result.current.board.e7).toEqual({ type: 'P', color: 'b' });
+    expect(result.current.board.e4).toEqual({ type: 'P', color: 'w' });
+    expect(result.current.history).toHaveLength(2);
+    expect(result.current.moves).toEqual(['e4']);
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(result.current.board.e4).toBeUndefined();
+    expect(result.current.board.e2).toEqual({ type: 'P', color: 'w' });
+    expect(result.current.board.e7).toEqual({ type: 'P', color: 'b' });
+    expect(result.current.history).toHaveLength(1);
+    expect(result.current.moves).toHaveLength(0);
+  });
+});

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -51,12 +51,12 @@ function reducer(state: State, action: Action): State {
     }
     case 'UNDO': {
       if (state.history.length > 1) {
-        const newHistory = state.history.slice(0, -2);
+        const newHistory = state.history.slice(0, -1);
         const board = newHistory[newHistory.length - 1] || initialBoard();
         return {
           board,
           history: newHistory.length ? newHistory : [initialBoard()],
-          moves: state.moves.slice(0, -2),
+          moves: state.moves.slice(0, -1),
         };
       }
       return state;


### PR DESCRIPTION
## Summary
- Fix game store reducer undo to drop only last move from history and moves
- Add tests for single and consecutive undo operations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d3fc587ac8328836177ebe8c3a2f8