### PR TITLE
Support full chess piece set

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,14 @@ function pieceSymbol(piece: Piece | undefined): string | null {
     bP: '♟︎',
     wK: '♔',
     bK: '♚',
+    wQ: '♕',
+    bQ: '♛',
+    wR: '♖',
+    bR: '♜',
+    wB: '♗',
+    bB: '♝',
+    wN: '♘',
+    bN: '♞',
   };
   return symbols[piece.color + piece.type];
 }

--- a/src/boardStore.tsx
+++ b/src/boardStore.tsx
@@ -5,15 +5,29 @@ import React, {
   useMemo,
   ReactNode,
 } from 'react';
-import type { Board } from './types';
+import { Chess } from 'chess.js';
+import { INITIAL_FEN } from './constants';
+import type { Board, Piece } from './types';
 
 function initialBoard(): Board {
-  return {
-    a8: { type: 'K', color: 'b' },
-    e7: { type: 'P', color: 'b' },
-    e2: { type: 'P', color: 'w' },
-    h1: { type: 'K', color: 'w' },
-  };
+  const game = new Chess(INITIAL_FEN);
+  const boardState = game.board();
+  const board: Board = {};
+  const files = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+  for (let r = 0; r < 8; r++) {
+    for (let f = 0; f < 8; f++) {
+      const piece = boardState[r][f];
+      if (piece) {
+        const file = files[f];
+        const rank = 8 - r;
+        board[file + rank] = {
+          type: piece.type.toUpperCase() as Piece['type'],
+          color: piece.color as Piece['color'],
+        };
+      }
+    }
+  }
+  return board;
 }
 
 function movePiece(board: Board, from: string, to: string): Board {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,1 @@
-export const INITIAL_FEN = 'k7/4p3/8/8/8/8/4P3/7K w - - 0 1';
+export const INITIAL_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 export type Color = 'w' | 'b';
 
 export interface Piece {
-  type: 'P' | 'K';
+  type: 'P' | 'K' | 'Q' | 'R' | 'B' | 'N';
   color: Color;
 }
 


### PR DESCRIPTION
## Summary
- allow Piece.type to represent all six chess pieces and start from the standard opening position
- initialize board state from the full FEN via chess.js
- render symbols for queens, rooks, bishops and knights

## Testing
- `npm test`
- `npm run lint`
- `npm run e2e`

------
https://chatgpt.com/codex/tasks/task_e_689d3fc670cc8328ab918ac8203be768