### PR TITLE
ci: ignore missing Playwright traces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,4 @@ jobs:
         with:
           name: playwright-traces
           path: test-results
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- ensure Playwright traces upload step doesn't fail if no test results

## Testing
- `npm test` (fails: Jest encountered an unexpected token)

------
https://chatgpt.com/codex/tasks/task_e_689d5031f1e083288a63e7dccc93aab2