### PR TITLE
Export initial FEN constant

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,3 @@
+export const INITIAL_FEN =
+  'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
 


### PR DESCRIPTION
## Summary
- expose chess starting position as `INITIAL_FEN`

## Testing
- `npm test` *(fails: Jest parsing errors)*
- `npm run lint` *(fails: ESLint parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e6e300d083288048ac24dca5158e