### PR TITLE
chore: point index to TypeScript entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- fix index.html script to load TypeScript main entry

## Testing
- `npm run lint` *(fails: Parsing error: '}' expected in App.tsx; ';' expected in boardStore.tsx, etc.)*
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run dev -- --clearScreen false` & `curl -i http://localhost:5173/` & `curl -i http://localhost:5173/src/main.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a2e6e5da688328a14a28f7cb3bb340