### PR TITLE
Validate player piece before requesting legal moves

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,7 +78,7 @@ export default function App(): JSX.Element {
   const workerRef = useRef<Worker | null>(null);
   const gameRef = useRef(new Chess(fen || INITIAL_FEN));
   const { white, black, start, pause, reset } = useClock(300);
-  const [gameOver, setGameOver] = useState(false);
+  const [, setGameOver] = useState(false);
 
   useEffect(() => {
     start('white');
@@ -117,7 +117,9 @@ export default function App(): JSX.Element {
         case 'STALEMATE':
           setAnnouncement('Stalemate');
           break;
-
+        case 'LEGAL_MOVES':
+          setLegalMoves(data.moves);
+          break;
         case 'ERROR':
           setAnnouncement(data.message);
           if (data.legalMoves) {
@@ -168,7 +170,9 @@ export default function App(): JSX.Element {
   };
 
   const handleSquareClick = (square: string) => {
-
+    if (!selected) {
+      const piece = board[square];
+      if (!piece || piece.color !== 'w') return;
       setSelected(square);
       workerRef.current?.postMessage({
         type: 'GET_LEGAL_MOVES',


### PR DESCRIPTION
## Summary
- ensure `handleSquareClick` validates a white piece before selection
- update worker message handling for `LEGAL_MOVES`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a35c14e21883288b9dfe9642fd8732