### PR TITLE
feat: allow empty board squares

### DIFF
--- a/src/boardStore.tsx
+++ b/src/boardStore.tsx
@@ -30,7 +30,10 @@ function initialBoard(): Board {
 
 function movePiece(board: Board, from: string, to: string): Board {
   const moving = board[from];
-  const newBoard = { ...board };
+  if (!moving) {
+    return board;
+  }
+  const newBoard: Board = { ...board };
   newBoard[to] = moving;
   delete newBoard[from];
   return newBoard;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export interface Piece {
   color: Color;
 }
 
-export type Board = Record<string, Piece>;
+export type Board = Partial<Record<string, Piece>>;
 
 export interface Move {
   from: string;


### PR DESCRIPTION
## Summary
- support optional board squares with Partial<Record>
- guard piece moves when no piece exists

## Testing
- `npm test`
- `npm run lint` *(fails: 'setGameOver' is assigned a value but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68a3692459fc8328a70460239bd2fd34