### PR TITLE
Clear board selection on undo and reset

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -241,6 +241,8 @@ export default function App(): JSX.Element {
     importFEN(g.fen());
     newHistory.forEach((m) => addMove(m));
     workerRef.current?.postMessage({ type: 'INIT', fen: g.fen() } as WorkerRequest);
+    setSelected(null);
+    setLegalMoves([]);
     setAnnouncement('Undo last move');
   };
 
@@ -250,6 +252,8 @@ export default function App(): JSX.Element {
     setBoard(boardFromGame(g));
     importFEN(INITIAL_FEN);
     workerRef.current?.postMessage({ type: 'INIT', fen: INITIAL_FEN } as WorkerRequest);
+    setSelected(null);
+    setLegalMoves([]);
     setAnnouncement('Game reset');
     reset();
     start('white');


### PR DESCRIPTION
## Summary
- Clear the currently selected square and any highlighted legal moves after undo or reset actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a36925b7888328807ac1bb9fa0e614