### PR TITLE
Convert SAN legal moves to target squares

### DIFF
--- a/src/aiWorker.ts
+++ b/src/aiWorker.ts
@@ -21,13 +21,13 @@ self.onmessage = (e: MessageEvent<WorkerRequest>) => {
         send({ type: 'STALEMATE' });
       }
       break;
-    case 'GET_LEGAL_MOVES':
-      send({
-        type: 'LEGAL_MOVES',
-        square: data.square,
-        moves: game.moves({ square: data.square, verbose: false }) as string[],
-      });
+    case 'GET_LEGAL_MOVES': {
+      const moves = game
+        .moves({ square: data.square, verbose: true })
+        .map(m => m.to);
+      send({ type: 'LEGAL_MOVES', square: data.square, moves });
       break;
+    }
     case 'PLAYER_MOVE': {
       let move = null;
       try {


### PR DESCRIPTION
## Summary
- send target squares rather than SAN strings when requesting legal moves

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a378047f188328901e3e18c4edf9ac