### PR TITLE
Record SAN moves and format PGN

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -106,7 +106,10 @@ export default function App(): JSX.Element {
         case 'AI_MOVE':
           aiMove(data.from, data.to);
           gameRef.current.move({ from: data.from, to: data.to, promotion: 'q' });
-          addMove(data.to);
+          const aiSan = gameRef.current
+            .history({ verbose: true })
+            .slice(-1)[0].san;
+          addMove(aiSan);
           setFen(gameRef.current.fen());
           setAnnouncement(`AI moved ${data.from} to ${data.to}`);
           start('white');
@@ -167,7 +170,10 @@ export default function App(): JSX.Element {
     if (!move) return;
     playerMove(from, to);
     workerRef.current?.postMessage({ type: 'PLAYER_MOVE', from, to } as WorkerRequest);
-    addMove(to);
+    const san = gameRef.current
+      .history({ verbose: true })
+      .slice(-1)[0].san;
+    addMove(san);
     setFen(gameRef.current.fen());
     setAnnouncement(`Player moved ${from} to ${to}`);
     setLegalMoves([]);

--- a/src/useGameStore.ts
+++ b/src/useGameStore.ts
@@ -57,7 +57,9 @@ export default function useGameStore(): GameStore {
 
   // export the move history as a simple PGN string
   const exportPGN = useCallback(() => {
-    return history.join(' ');
+    return history
+      .map((move, idx) => (idx % 2 === 0 ? `${Math.floor(idx / 2) + 1}. ${move}` : move))
+      .join(' ');
   }, [history]);
 
   // import a FEN position and reset move history


### PR DESCRIPTION
## Summary
- capture SAN notation after each player and AI move and store in history
- format PGN export with move numbers and SAN strings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3ae8b751c8328b64ed63b2dbd51bf