### PR TITLE
Reset state after importing FEN positions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,7 +68,8 @@ function formatTime(seconds: number): string {
 export default function App(): JSX.Element {
   const { board, orientation } = useBoardState();
   const { playerMove, aiMove, flipOrientation, setBoard } = useBoardActions();
-  const { fen, setFen, history, addMove, exportPGN, importFEN } = useGameStore();
+  const { fen, setFen, history, addMove, exportPGN, importFEN } =
+    useGameStore();
   const [selected, setSelected] = useState<string | null>(null);
 
   const [legalMoves, setLegalMoves] = useState<string[]>([]);
@@ -80,7 +81,6 @@ export default function App(): JSX.Element {
   const { white, black, start, pause, reset } = useClock(300);
 
   const [gameOver, setGameOver] = useState(false);
-
 
   useEffect(() => {
     start('white');
@@ -105,14 +105,20 @@ export default function App(): JSX.Element {
       switch (data.type) {
         case 'AI_MOVE':
           aiMove(data.from, data.to);
-          gameRef.current.move({ from: data.from, to: data.to, promotion: 'q' });
+          gameRef.current.move({
+            from: data.from,
+            to: data.to,
+            promotion: 'q',
+          });
           addMove(data.to);
           setFen(gameRef.current.fen());
           setAnnouncement(`AI moved ${data.from} to ${data.to}`);
           start('white');
           break;
         case 'CHECKMATE':
-          setAnnouncement(`Checkmate: ${data.winner === 'w' ? 'White' : 'Black'} wins`);
+          setAnnouncement(
+            `Checkmate: ${data.winner === 'w' ? 'White' : 'Black'} wins`,
+          );
           setGameOver(true);
           pause();
           break;
@@ -127,7 +133,7 @@ export default function App(): JSX.Element {
         case 'ERROR':
           setAnnouncement(data.message);
           if (data.legalMoves) {
-            const moves = data.legalMoves.map(m => {
+            const moves = data.legalMoves.map((m) => {
               const match = m.match(/[a-h][1-8]/g);
               return match ? match[match.length - 1] : m;
             });
@@ -166,7 +172,11 @@ export default function App(): JSX.Element {
     const move = gameRef.current.move({ from, to, promotion: 'q' });
     if (!move) return;
     playerMove(from, to);
-    workerRef.current?.postMessage({ type: 'PLAYER_MOVE', from, to } as WorkerRequest);
+    workerRef.current?.postMessage({
+      type: 'PLAYER_MOVE',
+      from,
+      to,
+    } as WorkerRequest);
     addMove(to);
     setFen(gameRef.current.fen());
     setAnnouncement(`Player moved ${from} to ${to}`);
@@ -177,12 +187,14 @@ export default function App(): JSX.Element {
   const handleSquareClick = (square: string) => {
     if (gameOver) return;
     if (!selected) {
-
       const piece = board[square];
       if (!piece || piece.color !== 'w') return;
 
       setSelected(square);
-      workerRef.current?.postMessage({ type: 'GET_LEGAL_MOVES', square } as WorkerRequest);
+      workerRef.current?.postMessage({
+        type: 'GET_LEGAL_MOVES',
+        square,
+      } as WorkerRequest);
       return;
     }
 
@@ -247,7 +259,10 @@ export default function App(): JSX.Element {
     const newHistory = history.slice(0, -2);
     importFEN(g.fen());
     newHistory.forEach((m) => addMove(m));
-    workerRef.current?.postMessage({ type: 'INIT', fen: g.fen() } as WorkerRequest);
+    workerRef.current?.postMessage({
+      type: 'INIT',
+      fen: g.fen(),
+    } as WorkerRequest);
     setSelected(null);
     setLegalMoves([]);
     setAnnouncement('Undo last move');
@@ -259,7 +274,10 @@ export default function App(): JSX.Element {
     gameRef.current = g;
     setBoard(boardFromGame(g));
     importFEN(INITIAL_FEN);
-    workerRef.current?.postMessage({ type: 'INIT', fen: INITIAL_FEN } as WorkerRequest);
+    workerRef.current?.postMessage({
+      type: 'INIT',
+      fen: INITIAL_FEN,
+    } as WorkerRequest);
     setSelected(null);
     setLegalMoves([]);
     setAnnouncement('Game reset');
@@ -285,9 +303,17 @@ export default function App(): JSX.Element {
       gameRef.current = g;
       setBoard(boardFromGame(g));
       importFEN(fenInput);
-      workerRef.current?.postMessage({ type: 'INIT', fen: fenInput } as WorkerRequest);
+      workerRef.current?.postMessage({
+        type: 'INIT',
+        fen: fenInput,
+      } as WorkerRequest);
       setAnnouncement('FEN imported');
       setGameOver(false);
+      reset();
+      start('white');
+      setFenInput('');
+      setSelected(null);
+      setLegalMoves([]);
     } catch {
       setAnnouncement('Invalid FEN');
     }
@@ -324,11 +350,10 @@ export default function App(): JSX.Element {
               tabIndex={0}
               aria-label={`square ${sq}${
                 piece
-                  ?
-                      ' with ' +
-                      (piece.color === 'w' ? 'white' : 'black') +
-                      ' ' +
-                      pieceNames[piece.type]
+                  ? ' with ' +
+                    (piece.color === 'w' ? 'white' : 'black') +
+                    ' ' +
+                    pieceNames[piece.type]
                   : ''
               }`}
               onClick={() => handleSquareClick(sq)}
@@ -342,7 +367,6 @@ export default function App(): JSX.Element {
                 border: 'none',
                 padding: 0,
                 fontSize: 32,
-
               }}
             >
               {piece && <span className="piece">{pieceSymbol(piece)}</span>}
@@ -398,4 +422,3 @@ export default function App(): JSX.Element {
     </Box>
   );
 }
-


### PR DESCRIPTION
## Summary
- Reset clock, board selection, and legal moves when importing a FEN
- Clear FEN input and start clock for White after import

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3ae89f82c83288ea3ac0c554db702