### PR TITLE
Restart white clock after undo

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -252,6 +252,8 @@ export default function App(): JSX.Element {
     setLegalMoves([]);
     setAnnouncement('Undo last move');
     setGameOver(false);
+    pause();
+    start('white');
   };
 
   const handleReset = () => {


### PR DESCRIPTION
## Summary
- Resume the white timer after an undo while ensuring previous intervals are cleared

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3ae8904b0832898f74ea553418f90