### PR TITLE
Highlight selected square on board

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -317,6 +317,7 @@ export default function App(): JSX.Element {
               component="button"
               data-square={sq}
               data-legal={isLegal ? 'true' : undefined}
+              data-selected={selected === sq ? 'true' : undefined}
               role="gridcell"
               ref={(el) => {
                 squareRefs.current[sq] = el as HTMLButtonElement | null;
@@ -342,7 +343,9 @@ export default function App(): JSX.Element {
                 border: 'none',
                 padding: 0,
                 fontSize: 32,
-
+                '&[data-selected="true"]': {
+                  outline: '2px solid #f00',
+                },
               }}
             >
               {piece && <span className="piece">{pieceSymbol(piece)}</span>}


### PR DESCRIPTION
## Summary
- mark board squares with `data-selected` when chosen
- style selected squares with a visible outline

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3ae8be9848328838c8ae02ba2d1d4