### PR TITLE
Clear selection on board flip

### DIFF
--- a/src/App.flip.test.tsx
+++ b/src/App.flip.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import App from './App';
+import { BoardProvider } from './boardStore';
+
+type WorkerRequest = import('./types').WorkerRequest;
+
+class MockWorker {
+  static instances: MockWorker[] = [];
+  public onmessage: ((e: { data: unknown }) => void) | null = null;
+  constructor() {
+    MockWorker.instances.push(this);
+  }
+  postMessage(msg: WorkerRequest) {
+    if (msg.type === 'GET_LEGAL_MOVES') {
+      this.onmessage?.({
+        data: { type: 'LEGAL_MOVES', square: msg.square, moves: ['e3', 'e4'] },
+      });
+    }
+  }
+  terminate() {}
+}
+
+test('flip clears selection and legal moves', async () => {
+  const globalObj = global as unknown as { Worker: unknown };
+  const OriginalWorker = globalObj.Worker;
+  globalObj.Worker = MockWorker as unknown;
+
+  const theme = createTheme();
+  const { container, getByText } = render(
+    <ThemeProvider theme={theme}>
+      <BoardProvider>
+        <App />
+      </BoardProvider>
+    </ThemeProvider>,
+  );
+
+  const e2 = container.querySelector('[data-square="e2"]') as HTMLElement;
+  fireEvent.click(e2);
+
+  const e3 = container.querySelector('[data-square="e3"]') as HTMLElement;
+  const e4 = container.querySelector('[data-square="e4"]') as HTMLElement;
+  await waitFor(() => expect(e3.getAttribute('data-legal')).toBe('true'));
+
+  const flipBtn = getByText('Flip Board');
+  fireEvent.click(flipBtn);
+
+  const announcer = container.querySelector('[data-testid="announcer"]') as HTMLElement;
+  await waitFor(() => {
+    expect(announcer.textContent).toBe('Board orientation changed; selection cleared');
+    expect(e3.getAttribute('data-legal')).toBeNull();
+    expect(e4.getAttribute('data-legal')).toBeNull();
+  });
+
+  fireEvent.click(e4);
+  expect(e2.textContent).toBe('♙');
+  expect(e4.textContent).toBe('');
+
+  globalObj.Worker = OriginalWorker;
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -232,9 +232,10 @@ export default function App(): JSX.Element {
   };
 
   const handleFlip = () => {
-    const newOrientation = orientation === 'white' ? 'black' : 'white';
     flipOrientation();
-    setAnnouncement(`Board orientation is now ${newOrientation} at bottom`);
+    setSelected(null);
+    setLegalMoves([]);
+    setAnnouncement('Board orientation changed; selection cleared');
   };
 
   const handleUndo = () => {

--- a/tests/chess.spec.ts
+++ b/tests/chess.spec.ts
@@ -26,7 +26,7 @@ test('board has grid roles and announces moves and orientation', async ({ page }
   await expect.poll(async () => await announcer.textContent()).toContain('moved');
 
   await page.getByRole('button', { name: 'Toggle board orientation' }).click();
-  await expect(announcer).toHaveText(/Board orientation is now (white|black) at bottom/);
+  await expect(announcer).toHaveText('Board orientation changed; selection cleared');
 });
 
 test('announces illegal move', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Clear any selected piece and legal moves when flipping board orientation
- Announce orientation change and cleared selection
- Add unit and E2E test updates for flip behaviour

## Testing
- `npm run lint`
- `npm test`
- `npm run e2e` *(fails: locator.waitFor timeout for legal move marker)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ae886e3c8328911587015122255c